### PR TITLE
Reduce size, serve production build

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,6 @@
+http://127.0.0.1:3000
+
+encode zstd gzip
+file_server {
+	root ./build
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 ARG NODE_IMAGE=node:18.6.0-alpine3.15
+ARG CADDY_IMAGE=caddy:2.5.2-alpine
 
-FROM $NODE_IMAGE
+FROM $NODE_IMAGE as builder
 
 ARG NODE_SPACE_SIZE=10240
 ENV NODE_OPTIONS="--openssl-legacy-provider --max-old-space-size=$NODE_SPACE_SIZE"
@@ -20,6 +21,13 @@ RUN cd /ui && \
 	npm install && \
 	npm run build
 
+FROM $CADDY_IMAGE
+
+COPY --from=builder /ui/build /ui/build
+COPY --from=builder /ui/Caddyfile /ui/Caddyfile
+
+WORKDIR /ui
+
 EXPOSE 3000
 
-CMD [ "npm", "run", "start" ]
+CMD [ "caddy", "run", "-config", "/ui/Caddyfile" ]


### PR DESCRIPTION
Reduce the size of the Docker image by only holding the production build of the UI. The files are served by Caddy server. For bundling, the production build files are still in /ui/build