### PR TITLE
feat: Added UI advanced options '-referer' header functionality

### DIFF
--- a/src/views/Edit/Sources/Network.js
+++ b/src/views/Edit/Sources/Network.js
@@ -67,6 +67,7 @@ const initSettings = (initialSettings) => {
 		forceFramerate: false,
 		framerate: 25,
 		userAgent: '',
+		referer: '',
 		http_proxy: '',
 		...settings.http,
 	};
@@ -285,6 +286,10 @@ const createInputs = (settings, config, skills) => {
 
 			if (settings.http.userAgent.length !== 0) {
 				input.options.push('-user_agent', settings.http.userAgent);
+			}
+
+			if (settings.http.referer.length !== 0) {
+				input.options.push('-referer', settings.http.referer);
 			}
 
 			if (settings.http.http_proxy.length !== 0) {
@@ -544,6 +549,15 @@ function AdvancedSettings(props) {
 										label="User-Agent"
 										value={settings.http.userAgent}
 										onChange={props.onChange('http', 'userAgent')}
+									/>
+								</Grid>
+								<Grid item xs={12}>
+									<TextField
+										variant="outlined"
+										fullWidth
+										label="Referer"
+										value={settings.http.referer}
+										onChange={props.onChange('http', 'referer')}
 									/>
 								</Grid>
 								<Grid item xs={12}>


### PR DESCRIPTION
Here are the key modifications made in this commit:

- A new field for "Referer" has been added to the HTTP settings section.
- The code has been updated to include the "Referer" field in the user interface, allowing users to input a value for the referer when configuring HTTP settings.
-  Appropriate changes have been made to ensure that the "Referer" field is included when generating input options for a network request.

**I noticed this functionality was unavailable and resorted to manually adding in the -referer field in _db.json_ which resulted in a few issues after restarted, after investigation I saw others dealing with the same issue so I decided to modify it. Currently working as intended!**

**Form change reference:**
![image](https://github.com/datarhei/restreamer-ui/assets/16753981/16e8c573-1e4b-4b4e-8cd1-2f6dfeb3a936)
