### PR TITLE
Fix chromecast

### DIFF
--- a/public/_playersite/videojs.js
+++ b/public/_playersite/videojs.js
@@ -6,8 +6,14 @@ var config = {
 	liveui: true,
 	responsive: true,
 	fluid: true,
-	// Needed to append the url orgin in order for the source to properly pass to the cast device
-	sources: [{ src: playerConfig.source, type: 'application/x-mpegURL' }],
+	// Needed to append the url origin in order for the source to properly pass to the cast device. Also provide a default reciever application ID
+	sources: [{ src: window.location.origin + '/' + playerConfig.source, type: 'application/x-mpegURL' }],
+	plugins: {
+		license: playerConfig.license,
+		chromecast: {
+			receiverApplicationId: 'CC1AD845'
+		},
+	},
 };
 
 if (chromecast) {


### PR DESCRIPTION
Chromecast needs to append the url origin for the source to properly pass to the cast device. And it appears to need the default receiver application ID.