### PR TITLE
Fix undefined error for `plugins`

### DIFF
--- a/public/_player/videojs/player.html
+++ b/public/_player/videojs/player.html
@@ -82,6 +82,7 @@
 		liveui: true,
 		responsive: true,
 		fluid: true,
+		plugins: {},
 		sources: [{ src: window.location.origin + '/' + playerConfig.source, type: 'application/x-mpegURL' }],
 	};
 


### PR DESCRIPTION
I am getting this error on the embedded media player page. Making this change manually on my site fixed it.
```
Uncaught TypeError: Cannot set properties of undefined (setting 'chromecast')
```