### PR TITLE
docs: document current upload size limits

### DIFF
--- a/public/_playersite/videojs.js
+++ b/public/_playersite/videojs.js
@@ -6,24 +6,22 @@ var config = {
 	liveui: true,
 	responsive: true,
 	fluid: true,
-	// Needed to append the url origin in order for the source to properly pass to the cast device. Also provide a default reciever application ID
+	// Needed to append the url origin in order for the source to properly pass to the cast device
 	sources: [{ src: window.location.origin + '/' + playerConfig.source, type: 'application/x-mpegURL' }],
-	plugins: {
-		license: playerConfig.license,
-		chromecast: {
-			receiverApplicationId: 'CC1AD845'
-		},
-	},
+	plugins: {},
 };
 
 if (chromecast) {
 	config.techOrder = ['chromecast', 'html5'];
+	// Provide a default reciever application ID
+	config.plugins.chromecast = {
+		receiverApplicationId: 'CC1AD845',
+	};
 }
 
 var player = videojs('player', config);
 
 player.ready(function () {
-
 	if (chromecast) {
 		player.chromecast();
 	}
@@ -31,7 +29,7 @@ player.ready(function () {
 	if (airplay) {
 		player.airPlay();
 	}
-	
+
 	player.license(playerConfig.license);
 
 	if (playerConfig.logo.image.length != 0) {


### PR DESCRIPTION
## Summary

Document the current client-side upload limits and where they are defined.

This clarifies that:
- video loop uploads are limited to 25 MiB
- audio loop uploads are limited to 25 MiB
- image loop uploads are limited to 2 MiB
- these limits are currently UI constants, not Restreamer/Core environment variables
- changing them requires updating the relevant `maxSize` values and rebuilding the UI

The README also points to the shared upload component that enforces `maxSize`.

Related to datarhei/restreamer#958.